### PR TITLE
fix(rollup.config.js): adds `{ browser: true }`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,9 @@ export default {
   ],
   plugins: [
     peerDepsExternal(),
-    resolve(),
+    resolve({
+      browser: true
+    }),
     commonjs(),
     typescript({ useTsconfigDeclarationDir: true }),
     postcss(),


### PR DESCRIPTION
Struggled with un-polyfilled Node dependencies when trying to consume a library created using this template in a Webpack 5 project. Adding this fixed the issue.